### PR TITLE
google Search Consoleの所有権確認用のタグを追加

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -22,6 +22,7 @@ const config: Configuration = {
     titleTemplate: '%s | 山口県 新型コロナウイルス感染症対策サイト',
     meta: [
       { charset: 'utf-8' },
+			{ name: 'google-site-verification',content: '3FCEH5Hl_JmE5VLHuUbXdnaf0zFais62pYXqBqZVQsw' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
       {
         hid: 'description',


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #23 

## ⛏ 変更内容 / Details of Changes
- SEO対策にあたって現状を把握するため、googleSearchConsoleを導入しようとしている。
そのために必要なmetaタグをサイトに追加した。