### PR TITLE
カードのタイトル「山口県内感染者発生状況」を「市町村別感染状況」に変更

### DIFF
--- a/components/cards/YamaguchiMapCard.vue
+++ b/components/cards/YamaguchiMapCard.vue
@@ -1,7 +1,7 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <svg-card
-		:title="$t('山口県内感染者発生状況')"
+		:title="$t('市町村別感染状況')"
 		:title-id="'map-in-yamaguchi'"
 		:date=MapUpdate
 		:url="'https://yamaguchi-opendata.jp/ckan/dataset/350001-covid19'"


### PR DESCRIPTION

## 📝 関連する issue / Related Issues
- #52 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 地図カードのタイトルを変更

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/42875682/81594859-86278500-93fc-11ea-9081-4680f9adcf3a.png)
