### PR TITLE
緊急事態宣言の解除についてのアイコンに変更 #73

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -13,6 +13,7 @@ $gray-5: #F8F9FA;
 $white: #FFFFFF;
 $link: #006CA8;
 $emergency: #FFE200;
+$noemergency: #D9D9D9;
 
 // ==================
 // shadow

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -12,9 +12,9 @@
           mdi-bullhorn
         </v-icon>
         <external-link
-          url="https://www.pref.yamaguchi.lg.jp/cms/a10900/corona/202005050001.html"
+          url="https://www.pref.yamaguchi.lg.jp/cms/a10900/corona/202005150001.html"
         >
-          {{ $t('山口県緊急事態宣言について') }}
+          {{ $t('山口県緊急事態宣言の解除について') }}
         </external-link>
       </span>
     </div>
@@ -98,8 +98,8 @@ export default Vue.extend({
       }
     }
     .WhatsNew-link-to-emergency-page {
-      background-color: $emergency;
-      border: 2px solid $emergency;
+      background-color: $noemergency;
+      border: 2px solid $noemergency;
       color: $gray-2;
       border-radius: 4px;
       font-size: 1rem;


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 📝 関連する issue / Related Issues
- #73 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 緊急事態宣言の解除についてのアイコンに変更

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/42875682/82029022-5533a280-96d1-11ea-92a5-0e2bf2740db4.png)
