### PR TITLE
サイドメニューの家庭でのマスクの捨て方の文言を修正

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -202,7 +202,7 @@ export default Vue.extend({
         },
         {
           icon: 'MaskTrashIcon',
-          title: this.$t('家庭でのマスクの捨て方'),
+          title: this.$t('ご家庭でのマスク等の捨て方'),
           link: 'https://www.kankyo.metro.tokyo.lg.jp/resource/500200a20200221162304660.files/200327_chirashi.pdf',
           divider: true
         },


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #95 

## ⛏ 変更内容 / Details of Changes
- サイドメニューの「家庭でのマスクの捨て方」の文言を「ご家庭でのマスク等の捨て方」へ変更
