### PR TITLE
「新型コロナウィルス感染症が心配なときに」のページの電話番号のリンクを正しいものに修正

### DIFF
--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -139,7 +139,7 @@
           <dl :class="$style.contact">
             <dt>{{ $t('毎日24時間対応') }}</dt>
             <dd>
-              <a :class="$style.tel" href="tel:0570-550571">
+              <a :class="$style.tel" href="tel:083-902-2510">
                 <icon-phone :class="$style.icon" aria-hidden="true" />
                 083-902-2510</a
               >
@@ -172,7 +172,7 @@
           <dl :class="$style.contact">
             <dt>{{ $t('毎日24時間対応') }}</dt>
             <dd>
-              <a :class="$style.tel" href="tel:0570-550571">
+              <a :class="$style.tel" href="tel:083-902-2510">
                 <icon-phone :class="$style.icon" aria-hidden="true" />
                 083-902-2510</a
               >


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #178 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「新型コロナウィルス感染症が心配なときに」のページの電話番号のリンクが東京都の電話番号のものになっていたため、山口県のリンクへと変更
