### PR TITLE
Fix:メニューボタンの開閉時にスクロールの挙動の修正

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -266,8 +266,6 @@ export default Vue.extend({
 }
 
 .open {
-  height: 100vh;
-
   @include largerThan($small) {
     overflow-x: hidden;
     overflow-y: auto;


### PR DESCRIPTION
Issue: #98

メニューボタンの開閉時にスクロールが予期しない位置に変更される不具合の修正。
メニューボタン開閉時に高さを100vhにしないようにした。

<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #98

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
・メニューボタンの開閉時にスクロールが予期しない位置に変更される不具合の修正
・メニューボタン開閉時に高さを100vhにしないようにした

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
