### PR TITLE
リンク切れ通知スクリプトの実行時にNo such file for directory になる問題の解決

### DIFF
--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -11,5 +11,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: link check
-        run: bash link_check/main.sh
+        run: bash main.sh
         working-directory: ./link_check


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 📝 関連する issue / Related Issues
- #123

## ⛏ 変更内容 / Details of Changes
リンク切れ通知スクリプトの名前を作業ディレクトリに合わせて修正
