### PR TITLE
日本語以外のページでワクチン情報をまだ掲載しない

### DIFF
--- a/components/MenuList.vue
+++ b/components/MenuList.vue
@@ -6,7 +6,11 @@
       :class="['MenuList-Item', { '-border': item.divider }]"
       @click="$emit('click', $event)"
     >
-      <component :is="linkTag(item.link)" v-bind="linkAttrs(item.link)">
+      <component
+        :is="linkTag(item.link)"
+        v-if="!item.onlyJPContent || $i18n.locale == 'ja'"
+        v-bind="linkAttrs(item.link)"
+      >
         <span v-if="item.icon" class="MenuList-Icon">
           <component :is="iconTag(item.icon)" v-bind="iconAttrs(item.icon)">
             {{ item.icon }}
@@ -45,6 +49,7 @@ type MenuItem = {
   title: string
   link: string
   divider?: boolean
+  onlyJPContent?: boolean
 }
 
 export default Vue.extend({

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -193,15 +193,17 @@ export default Vue.extend({
           title: this.$t('新型コロナウイルス感染症が心配なときに'),
           link: this.localePath('/flow')
         },
-	{
-	  icon: 'VaccineIcon',
-	  title: this.$t('ワクチン接種に関するお知らせ'),
-	  link: 'https://www.pref.yamaguchi.lg.jp/cms/a15200/kansensyou/ncorona-vaccine.html'
-	},
+        {
+          icon: 'VaccineIcon',
+          title: this.$t('ワクチン接種に関するお知らせ'),
+          link:
+            'https://www.pref.yamaguchi.lg.jp/cms/a15200/kansensyou/ncorona-vaccine.html'
+        },
         {
           icon: 'MaskTrashIcon',
           title: this.$t('ご家庭でのマスク等の捨て方'),
-          link: 'https://www.kankyo.metro.tokyo.lg.jp/resource/500200a20200221162304660.files/200327_chirashi.pdf',
+          link:
+            'https://www.kankyo.metro.tokyo.lg.jp/resource/500200a20200221162304660.files/200327_chirashi.pdf',
           divider: true
         },
         {

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -167,6 +167,7 @@ type Item = {
   title: TranslateResult
   link: string
   divider?: boolean
+  onlyJPContent?: boolean
 }
 
 export default Vue.extend({
@@ -197,7 +198,8 @@ export default Vue.extend({
           icon: 'VaccineIcon',
           title: this.$t('ワクチン接種に関するお知らせ'),
           link:
-            'https://www.pref.yamaguchi.lg.jp/cms/a15200/kansensyou/ncorona-vaccine.html'
+            'https://www.pref.yamaguchi.lg.jp/cms/a15200/kansensyou/ncorona-vaccine.html',
+          onlyJPContent: true
         },
         {
           icon: 'MaskTrashIcon',

--- a/components/flow/flow_sp.scss
+++ b/components/flow/flow_sp.scss
@@ -55,7 +55,6 @@
       border-radius: px2vw(25);
       background-image: url(/flow/check_circle-24px.svg);
       background-size: cover;
-      position: absolute;
       left: 0;
       right: 0;
       top: px2vw(-8);

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -16,7 +16,7 @@
     <whats-new class="mb-4" :items="newsItems" />
     <static-info
       class="mb-4"
-      :urlNotUse="localePath('/flow')"
+      :url-not-use="localePath('/flow')"
       url="https://www.pref.yamaguchi.lg.jp/cms/a10000/korona2020/202004240002.html"
       :text="$t('自分や家族の症状に不安や心配があればまずは電話相談をどうぞ')"
     />


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #197 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 海外の人向けのワクチン情報が山口県から出ていないので、日本語ページ以外では非表示にする
