### PR TITLE
カードの幅を他のものと揃えた

### DIFF
--- a/components/CocoaRedirectCard.vue
+++ b/components/CocoaRedirectCard.vue
@@ -1,12 +1,12 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard">
+  <div>
     <client-only>
       <div class="AppInstall">
         <div class="AppInstall-heading">
           <h3 class="AppInstall-title">
             {{ $t('新型コロナウイルス接触確認アプリ') }}
           </h3>
-          <h4 class="AppInstall-subtitle"> ( {{ $t('厚生労働省') }} ) </h4>
+          <h4 class="AppInstall-subtitle">( {{ $t('厚生労働省') }} )</h4>
         </div>
         <div class="AppInstall-content">
           <div class="AppInstall-block AppInstall-block-description">
@@ -45,12 +45,11 @@
         </div>
       </div>
     </client-only>
-  </v-col>
+  </div>
 </template>
 
 <style lang="scss">
 $mediumLarge: 900;
-$tinySmall: 420;
 @function px2vw($px, $vw: $mediumLarge) {
   @return $px / $vw * 100vw;
 }


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #218 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- COCOAのカードの幅が画面の半分サイズだったのを全体サイズに修正
